### PR TITLE
SG2042X4(2):fix watchdog bug

### DIFF
--- a/SG2042X4/common.h
+++ b/SG2042X4/common.h
@@ -4,7 +4,7 @@
 #include <pin.h>
 #include <gd32e50x.h>
 
-#define MCU_SW_VER	1
+#define MCU_SW_VER	2
 
 #define false 0
 #define true 1

--- a/SG2042X4/console.c
+++ b/SG2042X4/console.c
@@ -14,6 +14,7 @@
 #include <chip.h>
 #include <power.h>
 #include <mcu.h>
+#include <wdt.h>
 
 static struct ecdc_console *console;
 extern int power_is_on;
@@ -142,6 +143,15 @@ static void cmd_enprint(void *hint, int argc, char const *argv[])
 	}
 }
 
+static const char * const cmd_wdt_usage =
+"wdt\n"
+"    show wdt information\n";
+
+static void cmd_wdt(void *hint, int argc, char const *argv[])
+{
+	wdt_info_print();
+}
+
 uint32_t sys_rst_pin_list[1][2] = {
 	{SYS_RST_X_H_PORT, SYS_RST_X_H_PIN},
 };
@@ -162,6 +172,7 @@ static struct command command_list[] = {
 	{"temp", NULL, cmd_temp_usage, cmd_temp},
 	{"enprint", NULL, cmd_enprint_usage, cmd_enprint},
 	{"current", NULL, cmd_current_usage, cmd_current},
+	{"wdt", NULL, cmd_wdt_usage, cmd_wdt},
 };
 
 void print_usage(struct command *cmd)

--- a/SG2042X4/i2c-slaves/mcu.c
+++ b/SG2042X4/i2c-slaves/mcu.c
@@ -476,12 +476,10 @@ void mcu_process(void)
 			power_is_on = true;
 		timer_mdelay(500);
 		mcu_ctx.poweroff_reason = POWER_OFF_REASON_POWER_OFF;
-		wdt_reset();
 		break;
 	case CMD_RESET:
 		chip_reset();
 		mcu_ctx.poweroff_reason = POWER_OFF_REASON_RESET;
-		wdt_reset();
 		break;
 	case CMD_REBOOT:
 		chip_popd_reset_early();
@@ -489,7 +487,6 @@ void mcu_process(void)
 			power_is_on = true;
 		set_needpoweron();
 		mcu_ctx.poweroff_reason = POWER_OFF_REASON_REBOOT;
-		wdt_reset();
 		break;
 	case CMD_UPDATE:
 		nvic_enable_irq(I2C2_EV_IRQn);

--- a/SG2042X4/i2c-slaves/wdt.h
+++ b/SG2042X4/i2c-slaves/wdt.h
@@ -13,5 +13,7 @@
 void wdt_init(struct i2c_slave_ctx *i2c);
 void wdt_isr(void);
 void wdt_reset(void);
+void wdt_tick_task_enable(void);
+void wdt_info_print(void);
 
 #endif /* WDT_H_ */

--- a/SG2042X4/main.c
+++ b/SG2042X4/main.c
@@ -15,6 +15,7 @@
 #include <slave.h>
 #include <nct218.h>
 #include <mcu.h>
+#include <wdt.h>
 #include <chip.h>
 #include <loop.h>
 
@@ -29,6 +30,7 @@ int main(void)
 	chip_init();
 	slave_init();
 	board_init();
+	wdt_tick_task_enable();
 	console_add();
 	/* never return */
 	loop_start();


### PR DESCRIPTION
bug1: After software reboot or poweroff, the watchdog counter decrement task is registered again, causing kernel couldn't kick dog before counter becoming zero.
bug2: Watchdog reset itself will disable all interrupt include i2c.
bug3: When the os hang, watchdog fails to trigger a system reset by pull sys_reset pin, so we have to power down the whole board and power on to execute reset triggered by watchdog.